### PR TITLE
refactor: use upstream stateful chart for overseerr

### DIFF
--- a/applications/app-of-apps/templates/media-apps/overseerr.yaml
+++ b/applications/app-of-apps/templates/media-apps/overseerr.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   project: media
   source:
-    repoURL: {{ .Values.repository.url }}
-    targetRevision: HEAD
-    path: charts/x-arr
+    repoURL: {{ .Values.charts.repository }}
+    targetRevision: 1.1.0
+    chart: stateful
 
     helm:
       valuesObject:
@@ -20,9 +20,6 @@ spec:
           repository: lscr.io/linuxserver/overseerr
           tag: latest
           pullPolicy: Always
-        persistence:
-          config:
-            storageClass: longhorn-nvme
         resources:
           requests:
             cpu: 50m
@@ -50,6 +47,18 @@ spec:
             value: "1000"
           - name: PGID
             value: "1000"
+        extraVolumeMounts:
+          - name: config
+            mountPath: /config
+        extraVolumeClaimTemplates:
+          - metadata:
+              name: config
+            spec:
+              accessModes: [ "ReadWriteOnce" ]
+              storageClassName: longhorn-nvme
+              resources:
+                requests:
+                  storage: 512Mi
 
   destination:
     server: https://kubernetes.default.svc

--- a/applications/app-of-apps/values.yaml
+++ b/applications/app-of-apps/values.yaml
@@ -1,6 +1,9 @@
 repository:
   url: https://github.com/d3adb5/app-of-apps
 
+charts:
+  repository: https://charts.d3adb5.net/
+
 olm:
   namespace: operator-lifecycle-manager
 


### PR DESCRIPTION
Use the 'stateful' chart hosted on my chart repository for Overseerr.
