### PR TITLE
fix: use proper digest separator for prowlarr

### DIFF
--- a/applications/app-of-apps/templates/media-apps/prowlarr.yaml
+++ b/applications/app-of-apps/templates/media-apps/prowlarr.yaml
@@ -18,7 +18,7 @@ spec:
         replicaCount: 1
         image:
           repository: lscr.io/linuxserver/prowlarr
-          tag: "1.15.0sha256:335388a2b30603bcd69d7411f3bfb37c54a8799eb1f76bae1f42ec6b2f9a5a79"
+          tag: "1.15.0@sha256:335388a2b30603bcd69d7411f3bfb37c54a8799eb1f76bae1f42ec6b2f9a5a79"
           pullPolicy: IfNotPresent
         service:
           port: 9696


### PR DESCRIPTION
Use the proper digest separator for Prowlarr's image string.
