### PR TITLE
feat: revamp sso permissions management

### DIFF
--- a/applications/app-of-apps/templates/argo-cd/application.yaml
+++ b/applications/app-of-apps/templates/argo-cd/application.yaml
@@ -31,8 +31,10 @@ spec:
               requestedScopes: ["openid", "profile", "email", "groups"]
           rbac:
             policy.csv: |
-              g, Admin,   role:admin
-              g, difford, role:readonly
+              g, /Admin,          role:admin
+              g, /Argo CD/Admin,  role:admin
+              g, /Argo CD/Reader, role:readonly
+              g, difford,         role:readonly
 
         controller:
           replicas: 1


### PR DESCRIPTION
Grant readonly permissions to newly created groups, use full group path.
