### PR TITLE
feat: deploy jellyfin to media namespace

### DIFF
--- a/applications/app-of-apps/templates/media-apps/jellyfin.yaml
+++ b/applications/app-of-apps/templates/media-apps/jellyfin.yaml
@@ -1,0 +1,49 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: jellyfin
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: media
+  source:
+    repoURL: https://djjudas21.github.io/charts
+    targetRevision: 3.0.1
+    chart: jellyfin
+
+    helm:
+      valuesObject:
+        jellyfin:
+          mediaVolumes:
+            - name: movies
+              readOnly: true
+              existingClaim: media-library-movies
+            - name: tv
+              readOnly: true
+              existingClaim: media-library-tv
+        persistence:
+          config:
+            enabled: true
+            volumeClaimSpec:
+              storageClassName: longhorn-nvme
+          data:
+            enabled: true
+            volumeClaimSpec:
+              storageClassName: longhorn-nvme
+        ingress:
+          enabled: true
+          ingressClassName: nginx
+          hostname: jellyfin.d3adb5.net
+          annotations:
+            cert-manager.io/cluster-issuer: letsencrypt
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .Values.media.namespace }}
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
Deploy Jellyfin, an alternative to Plex and Kodi, to the media
namespace.
