### PR TITLE
fix(argo-cd): disable linkerd proxy injection on redis secret init

### DIFF
--- a/app-of-apps/templates/argo-cd/application.yaml
+++ b/app-of-apps/templates/argo-cd/application.yaml
@@ -18,6 +18,10 @@ spec:
           podAnnotations:
             linkerd.io/inject: enabled
 
+        redisSecretInit:
+          podAnnotations:
+            linkerd.io/inject: disabled
+
         configs:
           params:
             server.insecure: true


### PR DESCRIPTION
Disable Linkerd proxy injection on the Pods used to initialize the Redis secret for Argo CD. This avoids adding a container to the Job's Pod and consequently keeping the job in an uncomplete state forever.
