### PR TITLE
fix(transmission): roll back to 4.0.5

### DIFF
--- a/app-of-apps/templates/media-apps/transmission-movies.yaml
+++ b/app-of-apps/templates/media-apps/transmission-movies.yaml
@@ -16,7 +16,7 @@ spec:
         image:
           repository: lscr.io/linuxserver/transmission
           pullPolicy: IfNotPresent
-          tag: "4.0.6@sha256:cbd1f91f9c31615057ce2744aad8589f343176b4895d13afa656d2d54dd12b66"
+          tag: "4.0.5@sha256:c6a95f014f7ec812c9173be5a0afef4656e7c09be1c2d063786f42bdc3ee3d8a"
         podAnnotations:
           linkerd.io/inject: enabled
         replicaCount: 1

--- a/app-of-apps/templates/media-apps/transmission-tv.yaml
+++ b/app-of-apps/templates/media-apps/transmission-tv.yaml
@@ -16,7 +16,7 @@ spec:
         image:
           repository: lscr.io/linuxserver/transmission
           pullPolicy: IfNotPresent
-          tag: "4.0.6@sha256:cbd1f91f9c31615057ce2744aad8589f343176b4895d13afa656d2d54dd12b66"
+          tag: "4.0.5@sha256:c6a95f014f7ec812c9173be5a0afef4656e7c09be1c2d063786f42bdc3ee3d8a"
         podAnnotations:
           linkerd.io/inject: enabled
         replicaCount: 1


### PR DESCRIPTION
Roll back to Transmission version 4.0.5 due to issues with the latest
version causing it to be blocked by certain torrent trackers, such as
AnimeBytes.
